### PR TITLE
Load selected gallery image into attraction hero banner

### DIFF
--- a/script.js
+++ b/script.js
@@ -145,11 +145,19 @@
 
             const galleryContainer = document.getElementById('park-gallery-container');
             galleryContainer.innerHTML = '';
-            data.gallery.forEach(imageUrl => {
+            data.gallery.forEach((imageUrl, index) => {
                 const img = document.createElement('img');
                 img.src = imageUrl;
                 img.alt = `${data.name} gallery image`;
                 img.onerror = () => { img.style.display = 'none'; };
+                img.addEventListener('click', () => {
+                    parkHeroImage.src = imageUrl;
+
+                    const activeThumbnail = galleryContainer.querySelector('.active');
+                    if (activeThumbnail) activeThumbnail.classList.remove('active');
+                    img.classList.add('active');
+                });
+                if (index === 0) img.classList.add('active');
                 galleryContainer.appendChild(img);
             });
 

--- a/styles.css
+++ b/styles.css
@@ -294,6 +294,11 @@ button { background: none; border: none; font: inherit; color: inherit; cursor: 
     box-shadow: 0 5px 15px rgba(0, 0, 0, 0.2);
 }
 
+.gallery-container img.active {
+    outline: 2px solid var(--sage-green);
+    outline-offset: 2px;
+}
+
 #cursor {
     position: fixed;
     width: 10px;


### PR DESCRIPTION
### Motivation
- Enable clicking a gallery thumbnail in the park detail view to load that image into the hero/banner so users can view a selected full image directly.

### Description
- In `renderParkDetail` iterate gallery images with an index and attach a click listener to each thumbnail that sets `parkHeroImage.src` to the clicked `imageUrl` and toggles an `.active` class on the selected thumbnail.
- Preselect the first gallery thumbnail by adding `.active` when `index === 0`.
- Add CSS for `.gallery-container img.active` to visually indicate the selected thumbnail with an outline.

### Testing
- Ran `node --check script.js` which completed with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c284f65dbc8328b13f27b35a8588e0)